### PR TITLE
Fixed documentation, requirements. 

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,7 +6,7 @@ This code aims to export data from the MySQL database into redis
 # Requirements
 
 * System requirements to connect to MySQL: `sudo apt-get install libmysqlclient-dev`
-* Install required python packages: `sudo pip install -r requirements_misp.txt`
+* Install required python packages: `sudo pip install -r requirements.txt`
 * Configure the connection to MySQL and redis in `config.py`:
 
     ```python
@@ -18,7 +18,7 @@ This code aims to export data from the MySQL database into redis
     ```
 * Run a redis server listening on the socket you defined in the config file
 
-## Optional if you want to copy the redis database to an other machine
+## Optional if you want to copy the redis database to another machine
 
 * Connect to redis: `redis-cli -s <path to the redis socket>`
 * Save the database with `save`

--- a/grouping/README.md
+++ b/grouping/README.md
@@ -10,6 +10,7 @@ the analyst wants.
 
 # Requirements
 
+* sudo apt-get install python-dev libfuzzy-dev
 * access to the redis database created by `backend/make_snapshot.py`
 * python packages: `pip install -r requirements.txt`
 

--- a/grouping/requirements.txt
+++ b/grouping/requirements.txt
@@ -1,3 +1,4 @@
+pydeep
 pycrypto
 redis
 flask

--- a/grouping/website.py
+++ b/grouping/website.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 from flask import Flask, request, render_template

--- a/grouping/website.py
+++ b/grouping/website.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from flask import Flask, request, render_template


### PR DESCRIPTION
There were a few things that didn't work/were wrong when I cloned, 
- backend/README.md
  - It said the file was requirements_misp.txt, despite this not being a file
  - Simple typo of 'another'
- grouping/README.txt
  - Added instruction so that the pip modules compile -- you need a few dev libs
- grouping/requirements.txt
  - Added pydeep, this is needed 
- grouping/website.py
  - Only worked under python 2 for me -- it threw `ImportError: /usr/local/lib/python3.5/dist-packages/pydeep.cpython-35m-x86_64-linux-gnu.so: undefined symbol: PyString_FromStringAndSize
    ` if running under py3
